### PR TITLE
bugfix: wrong character in admin cache block

### DIFF
--- a/Block/Adminhtml/Cache.php
+++ b/Block/Adminhtml/Cache.php
@@ -23,8 +23,7 @@ class Cache extends OriginalCache
     protected function _construct()
     {
         parent::_construct();
-        $message = __('The Warm Cache will access a lot of store urls like product, 
-        category and cms pages to rebuild the caches. Do you agree to start now?');
+        $message = __('The Warm Cache will access a lot of store urls like product, category and cms pages to rebuild the caches. Do you agree to start now?');
         $this->buttonList->add(
             'warm_cache',
             [

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "require": {
     },
     "type": "magento2-module",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A warm cache extension for Magento 2.1 and 2.2",
     "autoload": {
         "files": [


### PR DESCRIPTION
Hi!
We forked your really great module.
Unfortunately the Run warm cache button in system -> cache management doesn't work because of a wrong character in the button o'clock message.