### PR TITLE
Update WarmCache.php

### DIFF
--- a/Console/Command/WarmCache.php
+++ b/Console/Command/WarmCache.php
@@ -58,8 +58,10 @@ class WarmCache extends Command
         InputInterface $input,
         OutputInterface $output
     ) {
-        $this->appState->setAreaCode('adminhtml');
-        /**
+        if (!$this->appState->getAreaCode()) {
+            $this->appState->setAreaCode('adminhtml');
+        }
+         /**
          * @var $helper Data
          */
         $helper = ObjectManager::getInstance()->create(Data::class);


### PR DESCRIPTION
prevent error:
[Magento\Framework\Exception\LocalizedException]
Area code is already set